### PR TITLE
Fix to extension support

### DIFF
--- a/Widget.php
+++ b/Widget.php
@@ -68,7 +68,7 @@ class Widget extends InputWidget
             'url' => $this->uploadUrl,
             'name' => $this->uploadParameter,
             'maxSize' => $this->maxSize / 1024,
-            'allowedExtensions' => ['jpg', 'jpeg', 'png', 'gif'],
+            'allowedExtensions' => explode(', ', $this->extensions),
             'size_error_text' => Yii::t('cropper', 'TOO_BIG_ERROR', ['size' => $this->maxSize / (1024 * 1024)]),
             'ext_error_text' => Yii::t('cropper', 'EXTENSION_ERROR', ['formats' => $this->extensions]),
             'accept' => 'image/*'

--- a/assets/js/cropper.js
+++ b/assets/js/cropper.js
@@ -25,7 +25,7 @@
                         return false;
                     }
 
-                    if (!inArray(options['allowedExtensions'], extension)) {
+                    if (!inArray(options['allowedExtensions'], extension.toLowerCase())) {
                         showError($widget, options['ext_error_text']);
                         $progress.addClass('hidden');
                         return false;


### PR DESCRIPTION
The problems I identified were the following:
- I was not able to modify the list of supported extensions;
- images with upper case extensions were not accepted by the widget.

To solve the two problems:
- I updated Widget.php in order to populate the allowedExtensions setting with the extensions specified in the extensions parameters of the widget;
- I updated cropper.js in order to convert the image extension to lower-case before comparing it with the accepted extensions.